### PR TITLE
Single thread compilation of expressions

### DIFF
--- a/src/main/java/org/mitre/synthea/helpers/ExpressionProcessor.java
+++ b/src/main/java/org/mitre/synthea/helpers/ExpressionProcessor.java
@@ -102,13 +102,17 @@ public class ExpressionProcessor {
     String wrappedExpression = convertParameterizedExpressionToCql(cleanExpression);
 
     // Compile our constructed CQL expression into elm once for execution
+    // The compiler isn't thread safe, so only allow one thread at a time
     this.elm = cqlToElm(wrappedExpression);
-    try {
-      this.library = CqlLibraryReader.read(new ByteArrayInputStream(
-          elm.getBytes(StandardCharsets.UTF_8)));
-    } catch (IOException | JAXBException ex) {
-      throw new RuntimeException(ex);
+    synchronized (ExpressionProcessor.class) {
+      try {
+        this.library = CqlLibraryReader.read(new ByteArrayInputStream(
+            elm.getBytes(StandardCharsets.UTF_8)));
+      } catch (IOException | JAXBException ex) {
+        throw new RuntimeException(ex);
+      }
     }
+
     this.context = new Context(library);
     this.expression = expression;
   }


### PR DESCRIPTION
Compilation isn't thread safe, resulting in odd errors when generating populations larger than 1